### PR TITLE
 Add option to make list of syntax highlighting list shorter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ FROM python:${PYTHON_VERSION}-slim as build-deps
     WORKDIR /app
 
     COPY requirements.txt .
+    COPY syntax_highlighting.json .
 
     RUN python -m venv .venv
     ENV PATH="/app/.venv/bin:$PATH"

--- a/paste_bin/config.py
+++ b/paste_bin/config.py
@@ -83,17 +83,6 @@ class Settings(BaseSettings):
     BRANDING: BrandSettings = BrandSettings()
     STORAGE: StorageSettings = StorageSettings()
     CACHE: CacheSettings = CacheSettings()
-    SYNTAX_HIGHLIGHTING_LANGUAGES: list[str] = [
-            'c',
-            'cpp',
-            'python',
-            'rust',
-            'java',
-            'csharp',
-            'bash',
-            'json',
-            'csv'
-            ]
 
     def get_syntax_highlighting_languages(self) -> list[str]:
         with open('/app/syntax_highlighting.json') as f:

--- a/paste_bin/config.py
+++ b/paste_bin/config.py
@@ -82,7 +82,8 @@ class Settings(BaseSettings):
     BRANDING: BrandSettings = BrandSettings()
     STORAGE: StorageSettings = StorageSettings()
     CACHE: CacheSettings = CacheSettings()
-    SYNTAX_HIGHLIGHTING_LANGUAGES: list[str] = ['c', 'cpp', 'python']
+    # SYNTAX_HIGHLIGHTING_LANGUAGES: list[str] = ['c', 'cpp', 'python']
+    SYNTAX_HIGHLIGHTING_LANGUAGES: list[str] = []
 
     MAX_BODY_SIZE: int = 2*(10**6)
     LOG_LEVEL: str = "WARNING"

--- a/paste_bin/config.py
+++ b/paste_bin/config.py
@@ -82,6 +82,7 @@ class Settings(BaseSettings):
     BRANDING: BrandSettings = BrandSettings()
     STORAGE: StorageSettings = StorageSettings()
     CACHE: CacheSettings = CacheSettings()
+    SYNTAX_HIGHLIGHTING_LANGUAGES: list[str] = ['c', 'cpp', 'python']
 
     MAX_BODY_SIZE: int = 2*(10**6)
     LOG_LEVEL: str = "WARNING"

--- a/paste_bin/config.py
+++ b/paste_bin/config.py
@@ -4,6 +4,7 @@ from enum import Enum
 
 from pydantic import BaseModel, BaseSettings, validator, SecretStr
 from pytz import all_timezones_set
+import json
 
 
 class StorageTypes(str, Enum):
@@ -74,16 +75,30 @@ class StorageSettings(BaseModel):
 
 
 class Settings(BaseSettings):
-    TIME_ZONE: str = "Europe/London"
-    NEW_AT_INDEX: bool = False
+    TIME_ZONE: str = "Europe/Warsaw"
+    NEW_AT_INDEX: bool = True
     ENABLE_PUBLIC_LIST: bool = False
     USE_LONG_ID: bool = False
     UI_DEFAULT: DefaultsSettings = DefaultsSettings()
     BRANDING: BrandSettings = BrandSettings()
     STORAGE: StorageSettings = StorageSettings()
     CACHE: CacheSettings = CacheSettings()
-    # SYNTAX_HIGHLIGHTING_LANGUAGES: list[str] = ['c', 'cpp', 'python']
-    SYNTAX_HIGHLIGHTING_LANGUAGES: list[str] = []
+    SYNTAX_HIGHLIGHTING_LANGUAGES: list[str] = [
+            'c',
+            'cpp',
+            'python',
+            'rust',
+            'java',
+            'csharp',
+            'bash',
+            'json',
+            'csv'
+            ]
+
+    def get_syntax_highlighting_languages(self) -> list[str]:
+        with open('/app/syntax_highlighting.json') as f:
+            return list(json.load(f))
+
 
     MAX_BODY_SIZE: int = 2*(10**6)
     LOG_LEVEL: str = "WARNING"

--- a/paste_bin/core/renderer.py
+++ b/paste_bin/core/renderer.py
@@ -7,6 +7,7 @@ from pygments.lexers import (find_lexer_class_by_name, get_all_lexers,
                              get_lexer_by_name)
 from pygments.util import ClassNotFound as PygmentsClassNotFound
 from quart.utils import run_sync
+from ..config import get_settings
 
 logger = logging.getLogger("paste_bin")
 
@@ -17,9 +18,17 @@ def get_highlighter_names() -> Generator[str, None, None]:
 
         :yield: Each highlighter name
     """
-    for lexer in get_all_lexers():
-        if lexer[1]:
-            yield lexer[1][0]
+    allowed_highlighters = get_settings().SYNTAX_HIGHLIGHTING_LANGUAGES
+    if allowed_highlighters is not None:
+        for language in allowed_highlighters:
+            lexer = get_lexer_by_name(language, stripall=True)
+            if lexer:
+                yield language
+            yield "text"
+    else:
+        for lexer in get_all_lexers():
+            if lexer[1]:
+                yield lexer[1][0]
 
 
 def is_valid_lexer_name(lexer_name: str) -> bool:

--- a/paste_bin/core/renderer.py
+++ b/paste_bin/core/renderer.py
@@ -19,7 +19,7 @@ def get_highlighter_names() -> Generator[str, None, None]:
         :yield: Each highlighter name
     """
     try:
-        allowed_highlighters = get_settings().SYNTAX_HIGHLIGHTING_LANGUAGES
+        allowed_highlighters = get_settings().get_syntax_highlighting_languages()
     except AttributeError:
         allowed_highlighters = []
     if allowed_highlighters is not None and len(allowed_highlighters) > 0:

--- a/paste_bin/core/renderer.py
+++ b/paste_bin/core/renderer.py
@@ -18,13 +18,15 @@ def get_highlighter_names() -> Generator[str, None, None]:
 
         :yield: Each highlighter name
     """
-    allowed_highlighters = get_settings().SYNTAX_HIGHLIGHTING_LANGUAGES
-    if allowed_highlighters is not None:
+    try:
+        allowed_highlighters = get_settings().SYNTAX_HIGHLIGHTING_LANGUAGES
+    except AttributeError:
+        allowed_highlighters = []
+    if allowed_highlighters is not None and len(allowed_highlighters) > 0:
         for language in allowed_highlighters:
             lexer = get_lexer_by_name(language, stripall=True)
             if lexer:
                 yield language
-            yield "text"
     else:
         for lexer in get_all_lexers():
             if lexer[1]:

--- a/paste_bin/static/script.js
+++ b/paste_bin/static/script.js
@@ -12,8 +12,8 @@ function validate_new_post_form() {
     let highlighter_value = highlighter_name.value.toLowerCase();
 
     if (highlighter_value === "") { return true; }
+
 // Check if the entered highlighter value is in the list of options
-    let found = false;
     for (let i = 0; i < data_list.options.length; i++) {
         if (data_list.options[i].value === highlighter_value) {
 			highlighter_name.value = highlighter_value;
@@ -21,7 +21,7 @@ function validate_new_post_form() {
         }
     }
 
-	//alert("Highlighter not found, using default one");
+	alert("Highlighter not found, using default one");
 	highlighter_name.value = "text";
     return true; // Allow form submission
 }

--- a/paste_bin/static/script.js
+++ b/paste_bin/static/script.js
@@ -13,18 +13,37 @@ function validate_new_post_form() {
 
     if (highlighter_value === "") { return true; }
 
-    highlighter_name.value = highlighter_value;
+    //highlighter_name.value = highlighter_value;
 
+    //for (let i = 0; i < data_list.options.length; i++) {
+        //if (data_list.options[i].value === highlighter_value) {
+            //return true;
+        //}
+    //}
+
+    //alert("Unknown highlighter name");
+	//highlighter_name.value = "";
+	//highlighter_name.focus();
+
+	//return false;
+// Check if the entered highlighter value is in the list of options
+    let found = false;
     for (let i = 0; i < data_list.options.length; i++) {
         if (data_list.options[i].value === highlighter_value) {
-            return true;
+            found = true;
+            break;
         }
     }
 
-    alert("Unknown highlighter name");
-    highlighter_name.focus();
+    if (!found) {
+        // Unknown highlighter name, set default and continue form submission
+        highlighter_name.value = "text";
+    } else {
+        // Known highlighter name, set entered value in lowercase
+        highlighter_name.value = highlighter_value;
+    }
 
-    return false;
+    return true; // Allow form submission
 }
 
 function enable_copy_share_link() {

--- a/paste_bin/static/script.js
+++ b/paste_bin/static/script.js
@@ -12,37 +12,17 @@ function validate_new_post_form() {
     let highlighter_value = highlighter_name.value.toLowerCase();
 
     if (highlighter_value === "") { return true; }
-
-    //highlighter_name.value = highlighter_value;
-
-    //for (let i = 0; i < data_list.options.length; i++) {
-        //if (data_list.options[i].value === highlighter_value) {
-            //return true;
-        //}
-    //}
-
-    //alert("Unknown highlighter name");
-	//highlighter_name.value = "";
-	//highlighter_name.focus();
-
-	//return false;
 // Check if the entered highlighter value is in the list of options
     let found = false;
     for (let i = 0; i < data_list.options.length; i++) {
         if (data_list.options[i].value === highlighter_value) {
-            found = true;
-            break;
+			highlighter_name.value = highlighter_value;
+			return true;
         }
     }
 
-    if (!found) {
-        // Unknown highlighter name, set default and continue form submission
-        highlighter_name.value = "text";
-    } else {
-        // Known highlighter name, set entered value in lowercase
-        highlighter_name.value = highlighter_value;
-    }
-
+	//alert("Highlighter not found, using default one");
+	highlighter_name.value = "text";
     return true; // Allow form submission
 }
 

--- a/syntax_highlighting.json
+++ b/syntax_highlighting.json
@@ -1,0 +1,11 @@
+[
+	"c",
+	"cpp",
+	"python",
+	"rust",
+	"java",
+	"csharp",
+	"bash",
+	"json",
+	"csv"
+]


### PR DESCRIPTION
When I was looking for most basic highlighting like for C, or CPP, It annoyed me that I need to search through hundreds of options barely anybody would ever use. Now you can preset available options