### PR TITLE
add suppoort for compose/dockerfile passthrough of [specified] variables from `.env`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,10 @@ FROM python:${PYTHON_VERSION}-alpine
     EXPOSE 8000
     ENV PATH="/app/.venv/bin:$PATH"
     ENV STORAGE__DISK__PASTE_ROOT="/app/data"
+    # Define .env vars with Default/error values
+    #   expected to be squashed by Docker-compose/etc.
+    ENV PASTE_ROOT=DF-UNDEFINED
+    ENV TIME_ZONE=DF-UNDEFINED
 
     COPY --from=build-content --link /app /app
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,9 @@ services:
     container_name: paste-bin
     image: ghcr.io/enchant97/hasty-paste:latest
     restart: unless-stopped
+    environment:
+      - PASTE_ROOT=${PASTE_ROOT:-DC-UNDEFINED}
+      - TIME_ZONE=${TIME_ZONE:-DC-UNDEFINED}
     volumes:
       - data:/app/data
     ports:


### PR DESCRIPTION
`install.md` suggests creating a `.env` file with `TIME_ZONE` and `PASTE_ROOT` settings.
Adding definitions to Dockerfile and docker-compose.yml to pass-through these values.

Discovery: I had a hard time getting the config-files right to change the timezone - the value in `config.py` does not seem to be consumed anywhere(?).